### PR TITLE
Make the black actually use black ascii BG colors.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 var QRCode = require('./../vendor/QRCode'),
     QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),
-    black = "  ",
+    black = "\033[40m  \033[0m",
     white = "\033[47m  \033[0m",
     toCell = function (isBlack) {
         return isBlack ? black : white;


### PR DESCRIPTION
The generated QR codes in the original version didn't work when using a
terminal with black text on white background.

This change makes the library use an actual color code for black (or at
least dark grey) background for the black color, just as it was using
the color code for white.
