### PR TITLE
Provided the functionality of error code levels for QR Code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ To display some data to the terminal just call:
 
     qrcode.generate('This will be a QRCode, eh!');
 
+You can even specify the error level (default is 'L'):
+    
+    qrcode.setErrorLevel(error='Q');
+    qrcode.generate('This will be a QRCode with error level Q!');
+
 If you don't want to display to the terminal but just want to string you can provide a callback:
 
     qrcode.generate('http://github.com', function (qrcode) {

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To display some data to the terminal just call:
 
 You can even specify the error level (default is 'L'):
     
-    qrcode.setErrorLevel(error='Q');
+    qrcode.setErrorLevel('Q');
     qrcode.generate('This will be a QRCode with error level Q!');
 
 If you don't want to display to the terminal but just want to string you can provide a callback:

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,8 +14,11 @@ var QRCode = require('./../vendor/QRCode'),
     };
 
 module.exports = {
+
+    error: QRErrorCorrectLevel.L,
+
     generate: function (input, cb) {
-        var qrcode = new QRCode(-1, QRErrorCorrectLevel.H);
+        var qrcode = new QRCode(-1, this.error);
         qrcode.addData(input);
         qrcode.make();
 
@@ -32,5 +35,10 @@ module.exports = {
 
         if (cb) cb(output);
         else console.log(output);
+    },
+
+    setErrorLevel: function (error) {
+       this.error = QRErrorCorrectLevel[error] || this.error;
     }
+
 };

--- a/test/main.js
+++ b/test/main.js
@@ -48,5 +48,16 @@ describe('in the main module', function() {
                 });
             });
         });
+
+        describe('the error level', function () {
+            it('should default to 1', function() {
+                expect(qrcode.error).to.be(1);
+            });
+
+            it('should not allow other levels', function() {
+                qrcode.setErrorLevel = 'something';
+                expect(qrcode.error).to.be(1);
+            }); 
+        });
     });
 });


### PR DESCRIPTION
A user should be able to set their own error level when generating a QR Code. Personally, I was having issues with the size of the QR Code in the terminal screen using the error level 'H'. Since the error correct level is commonly used for recovering data when the QR code is damaged, having an error level 'H' seems like overkill when displaying in the terminal.

Status: **Requesting Merge**

Reviewers: ** @gtanner @mwbrooks **

## Changes
- Default error correct level is 'L'
- Provide an error variable which can be set when calling setErrorLevel
- Added tests to reflect the change
