### PR TITLE
disable small qrcode output on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To display some data to the terminal just call:
     qrcode.generate('This will be a QRCode, eh!');
 
 You can even specify the error level (default is 'L'):
-    
+
     qrcode.setErrorLevel('Q');
     qrcode.generate('This will be a QRCode with error level Q!');
 
@@ -33,7 +33,7 @@ If you don't want to display to the terminal but just want to string you can pro
         console.log(qrcode);
     });
 
-If you want to display small output, provide `opts` with `small`:
+If you want to display small output, provide `small` option (small output is **experimental** and may display disorted with some fonts. It's disabled on *Windows*):
 
     qrcode.generate('This will be a small QRCode, eh!', {small: true});
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,6 @@
 var QRCode = require('./../vendor/QRCode'),
     QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),
+    isWin = /^win/.test(process.platform),
     black = "\033[40m  \033[0m",
     white = "\033[47m  \033[0m",
     toCell = function (isBlack) {
@@ -35,7 +36,7 @@ module.exports = {
         qrcode.make();
 
         var output = '';
-        if (opts && opts.small) {
+        if (opts && opts.small && !isWin) {
             var BLACK = true, WHITE = false;
             var moduleCount = qrcode.getModuleCount();
             var moduleData = qrcode.modules.slice();


### PR DESCRIPTION
Default font of Window commandline does not support unicode well. So small output is disabled on Windows.