### PR TITLE
Accept piped input

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If you want to display small output, provide `opts` with `small`:
 
     $ qrcode-terminal --help
     $ qrcode-terminal 'http://github.com'
+    $ echo 'http://github.com' | qrcode-terminal
 
 # Support
 

--- a/bin/qrcode-terminal.js
+++ b/bin/qrcode-terminal.js
@@ -9,35 +9,68 @@ var qrcode = require('../lib/main'),
     fs = require('fs');
 
 /*!
- * Parse the process name and input
+ * Parse the process name
  */
 
-var name = process.argv[1].replace(/^.*[\\\/]/, '').replace('.js', ''),
-    input = process.argv[2];
+var name = process.argv[1].replace(/^.*[\\\/]/, '').replace('.js', '');
 
 /*!
- * Display help
+ * Parse the input
  */
 
-if (!input || input === '-h' || input === '--help') {
-    help();
-    process.exit();
+if (process.stdin.isTTY) {
+    // called with input as argument, e.g.:
+    // ./qrcode-terminal.js "INPUT"
+
+    var input = process.argv[2];
+    handleInput(input);
+} else {
+    // called with piped input, e.g.:
+    // echo "INPUT" | ./qrcode-terminal.js
+
+    var readline = require('readline');
+
+    var interface = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        terminal: false
+    });
+
+    interface.on('line', function(line) {
+        handleInput(line);
+    });
 }
 
 /*!
- * Display version
+ * Process the input
  */
 
-if (input === '-v' || input === '--version') {
-    version();
-    process.exit();
+function handleInput(input) {
+
+    /*!
+     * Display help
+     */
+
+    if (!input || input === '-h' || input === '--help') {
+        help();
+        process.exit();
+    }
+
+    /*!
+     * Display version
+     */
+
+    if (input === '-v' || input === '--version') {
+        version();
+        process.exit();
+    }
+
+    /*!
+     * Render the QR Code
+     */
+
+    qrcode.generate(input);
 }
-
-/*!
- * Render the QR Code
- */
-
-qrcode.generate(input);
 
 /*!
  * Helper functions


### PR DESCRIPTION
This pull request makes it possible to generate QR Codes by piping data to the CLI tool.

Accepting input as argument (standard usage):

``` sh
./bin/qrcode-terminal.js 'http://github.com'
```

<img width="591" alt="qrcode-terminal-argument" src="https://cloud.githubusercontent.com/assets/868608/19531138/db1dcf96-9636-11e6-8b2b-22bc0a7b167a.png">

Accepting piped input:

``` sh
echo 'http://github.com' | ./bin/qrcode-terminal.js
```

<img width="639" alt="qrcode-terminal-pipe" src="https://cloud.githubusercontent.com/assets/868608/19531143/e2a26100-9636-11e6-9095-2fa238cbc630.png">

Fixes #18 
