### PR TITLE
bin as `qr` instead of `qrcode-terminal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ If you want to display small output, provide `opts` with `small`:
 
 ## Usage
 
-    $ qrcode-terminal --help
-    $ qrcode-terminal 'http://github.com'
+    $ qr --help
+    $ qr 'http://github.com'
 
 # Support
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   }],
   "main": "./lib/main",
   "bin": {
-      "qrcode-terminal": "./bin/qrcode-terminal.js"
+      "qr": "./bin/qrcode-terminal.js"
   },
   "preferGlobal": false,
   "devDependencies": {


### PR DESCRIPTION
Just a Suggestion...
Renamed the generated bin to `qr` intead of `qrcode-terminal`, for easy typing.