### PR TITLE
use hex escapes instead of octal to satisfy overzealous linters

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
 var QRCode = require('./../vendor/QRCode'),
     QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),
-    black = "\033[40m  \033[0m",
-    white = "\033[47m  \033[0m",
+    black = "\x1b[40m  \x1b[0m",
+    white = "\x1b[47m  \x1b[0m",
     toCell = function (isBlack) {
         return isBlack ? black : white;
     },


### PR DESCRIPTION
I ran into this issue trying to bundle an app with `nexe`:

> Acorn error: Octal literal in strict mode (3:13)                                                                                                                                 
> File: /home/git/hub-service-node/node_modules/qrcode-terminal/lib/main.js                                                                                                        
>                                                                                                                                                                                  
> 1  var QRCode = require('./../vendor/QRCode'),                                                                                                                                   
> 2      QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),                                                                                                  
> 3      black = "\033[40m  \033[0m", 

I think the diagnostic is wrong as this code shouldn't be evaluated by strict standards, but oct->hex seems like an easy enough compromise to convince it to include the file in the bundle.
