### PR TITLE
fix: use SPDX identifier.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "http://github.com/mwbrooks"
   }],
   "licenses": [{
-    "type": "Apache 2.0"
+    "type": "Apache-2.0"
   }],
   "main": "./lib/main",
   "bin": {


### PR DESCRIPTION
This change will help with tools that do automated license checks by switching to the SPDX identifier for the Apache 2.0 license.

---

https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license says:

> If you're using a common license such as BSD-2-Clause or MIT, add a current SPDX license identifier for the license you're using, like this:

https://spdx.org/licenses/ shows that the identifier is `Apache-2.0`.

---

Note: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license also states that the current format is deprecated, and the following is prefered:

```json
{ "license": "Apache-2.0" }
```

Happy to make that change if desired.