### PR TITLE
chore: fix license to be valid SPDX

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "email": "mikeywbrooks@gmail.com",
     "url": "http://github.com/mwbrooks"
   }],
-  "licenses": [{
-    "type": "Apache 2.0"
-  }],
+  "license": "Apache-2.0",
   "main": "./lib/main",
   "bin": {
       "qrcode-terminal": "./bin/qrcode-terminal.js"


### PR DESCRIPTION
This changes the license to a be a correct SPDX type. Currently the package.json is invalid.

The [npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license) clearly state that a "licenses array" is (no longer?) valid:
```json
// Not valid metadata
{
  "licenses" : [
    {
      "type": "MIT",
      "url": "https://www.opensource.org/licenses/mit-license.php"
    },
    {
      "type": "Apache-2.0",
      "url": "https://opensource.org/licenses/apache2.0.php"
    }
  ]
}
```