### PR TITLE
Use SPDX license id in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "http://github.com/mwbrooks"
   }],
   "licenses": [{
-    "type": "Apache 2.0"
+    "type": "Apache-2.0"
   }],
   "main": "./lib/main",
   "bin": {


### PR DESCRIPTION
### Description

`package.json` should include [SPDX license id](https://spdx.org/licenses/) in `license` field.

Hence: `Apache 2.0` → `Apache-2.0`.